### PR TITLE
Have ply send optimal video transcode based on roku-hdhomerun displaytype

### DIFF
--- a/hdhomerun/stream.py
+++ b/hdhomerun/stream.py
@@ -85,7 +85,9 @@ def startStream(channel,devices,quality):
     streamPath = getPath(channel)
     
     # ffmpeg -i ./stream/stream.ts -vcodec copy -acodec copy ./static/streams/"+channel+".m3u8"
-    pid = sub.Popen(["ffmpeg", "-i", "http://"+ip+":5004/auto/v"+channel+"?transcode="+quality, "-vcodec", "copy", "./static/streams/"+channel+".m3u8"]).pid
+    pid = sub.Popen(["ffmpeg", "-i", "http://"+ip+":5004/auto/v"+channel+quality, "-vcodec", "copy", "./static/streams/"+channel+".m3u8"]).pid
+    # below seems to work better with Roku HDMI Stick and 2100X (firmware 3.1 device) than above (Roku 3?) 
+    # pid = sub.Popen(["ffmpeg", "-i", "http://"+ip+":5004/auto/v"+channel+quality, "-vcodec", "copy", "-acodec", "libfdk_aac", "-ac", "2", "-ab", "192k", "-threads", "0", "-analyzeduration", "2000000", "-hls_time", "2", "-hls_wrap", "40", "-tune", "zerolatency", "-flags", "-global_header", "-fflags", "+genpts+igndts", "-movflags", "+faststart", "./static/streams/"+channel+".m3u8"]).pid
     
     with open(streamPath+".pid","w") as f:
             f.write(str(pid))

--- a/ply.py
+++ b/ply.py
@@ -75,15 +75,15 @@ class tune:
     def POST(self, channel):
 	''' Roku-HDHomerun gives ply its display type as query string 
 	attached to tune POST method, ply selects optimal HDHomerun encode '''
-	get_hdorsd = web.ctx["query"]
-	if get_hdorsd == "?HD":
-        	get_data = web.input(quality="heavy")
-	elif get_hdorsd == "?SD":
-        	get_data = web.input(quality="internet480")
-	else:
-        	get_data = web.input(quality="mobile")
-        devices = db.getDevices(dbase)
-        hdhr.stream.startStream(channel,devices,get_data.quality)
+	''' Tuning w/o transcode query selects HDHomeRun's default profile '''
+	hdhr_quality = ""
+ 	get_data = web.input(quality="")
+ 	if get_data.quality == "HD":
+ 		hdhr_quality = "?transcode=heavy"
+ 	elif get_data.quality == "SD":
+ 		hdhr_quality = "?transcode=internet480"
+ 	devices = db.getDevices(dbase)
+ 	hdhr.stream.startStream(channel,devices,hdhr_quality)
         
 class status:
     ''' Reports status of HDHR tuning and HLS process '''

--- a/ply.py
+++ b/ply.py
@@ -73,7 +73,13 @@ class logo:
 class tune:
     ''' Tunes HDHR and starts ffmpeg hls process '''
     def POST(self, channel):
-        get_data = web.input(quality="heavy")
+	''' Roku-HDHomerun gives ply its display type as query string 
+	attached to tune POST method, ply selects optimal HDHomerun encode '''
+	get_hdorsd = web.ctx["query"]
+	if get_hdorsd == "?HD":
+        	get_data = web.input(quality="heavy")
+	if get_hdorsd == "?SD":
+        	get_data = web.input(quality="internet480")
         devices = db.getDevices(dbase)
         hdhr.stream.startStream(channel,devices,get_data.quality)
         

--- a/ply.py
+++ b/ply.py
@@ -80,6 +80,8 @@ class tune:
         	get_data = web.input(quality="heavy")
 	elif get_hdorsd == "?SD":
         	get_data = web.input(quality="internet480")
+	else:
+        	get_data = web.input(quality="mobile")
         devices = db.getDevices(dbase)
         hdhr.stream.startStream(channel,devices,get_data.quality)
         

--- a/ply.py
+++ b/ply.py
@@ -78,7 +78,7 @@ class tune:
 	get_hdorsd = web.ctx["query"]
 	if get_hdorsd == "?HD":
         	get_data = web.input(quality="heavy")
-	if get_hdorsd == "?SD":
+	else if get_hdorsd == "?SD":
         	get_data = web.input(quality="internet480")
         devices = db.getDevices(dbase)
         hdhr.stream.startStream(channel,devices,get_data.quality)

--- a/ply.py
+++ b/ply.py
@@ -78,7 +78,7 @@ class tune:
 	get_hdorsd = web.ctx["query"]
 	if get_hdorsd == "?HD":
         	get_data = web.input(quality="heavy")
-	else if get_hdorsd == "?SD":
+	elif get_hdorsd == "?SD":
         	get_data = web.input(quality="internet480")
         devices = db.getDevices(dbase)
         hdhr.stream.startStream(channel,devices,get_data.quality)


### PR DESCRIPTION
I recently submitted a pull request (https://github.com/computmaxer/roku-hdhomerun/pull/5/files) to roku-hdhomerun that attaches a query string to the POST/tune channel method of wallop/ply to report what displaytype the requesting Roku is set to, i.e. SD or HD.

My proposed patch has ply use that information to select the optimal video transcode for the requesting display.
