### PR TITLE
Add ffmpeg arguments to make HDTC-2US streams work with Roku 2

### DIFF
--- a/hdhomerun/stream.py
+++ b/hdhomerun/stream.py
@@ -84,8 +84,11 @@ def startStream(channel,devices,quality):
     
     streamPath = getPath(channel)
     
-    # ffmpeg -i ./stream/stream.ts -vcodec copy -acodec copy ./static/streams/"+channel+".m3u8"
-    pid = sub.Popen(["ffmpeg", "-i", "http://"+ip+":5004/auto/v"+channel+"?transcode="+quality, "-vcodec", "copy", "./static/streams/"+channel+".m3u8"]).pid
+    # ffmpeg invocation: input from hdhomerun URL stream, video codec
+    # set to copy, audio codec set to mp3, hls_flags set to delete so
+    # we don't fill the disk when we watch, output to m3u8 file in
+    # static/streams directory.
+    pid = sub.Popen(["ffmpeg", "-i", "http://"+ip+":5004/auto/v"+channel+"?transcode="+quality, "-hls_flags", "delete_segments", "-vcodec", "copy", "-acodec", "mp3", "./static/streams/"+channel+".m3u8"]).pid
     
     with open(streamPath+".pid","w") as f:
             f.write(str(pid))


### PR DESCRIPTION
Hello,

I made two changes here in the ffmpeg invocation: 
1. mp3 audio codec.
2. hls_flags delete_segments.

My Roku 2 would not pick up any audio from ply from my HDTC-2US unless I transcoded audio to mp3 in ply's invocation of ffmpeg. Setting acodec to aac or copy resulted in silence. I don't have a Roku 3 mentioned in your readme.md, so I can't test this setup on your original configuration. If this new acodec argument does not work for newer Roku maybe there should be a configuration file where you enter your model number and ply does the right thing.

Once I got audio working, I noticed that static/streams started filling with ts segments, slowly filling the ply server disk for as long as I was watching the stream on the Roku. Adding the `hls_flags delete_segments` argument caused ffmpeg to delete the older ts segments resulting in a small rolling window of segments that did not fill the disk but kept the stream watchable. 

I am using ffmpeg git g1212e34 built on 20160924.

Thanks,
-R
